### PR TITLE
Expose bot via package init

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,10 @@
+"""Top-level package for the multipurpose website and bot."""
+
+from .bot import dp, main
+
+try:
+    from .web import app
+except Exception:  # pragma: no cover - web is optional
+    app = None
+
+__all__ = ["dp", "main", "app"]


### PR DESCRIPTION
## Summary
- expose `dp` and `main` via the package's `__init__`
- gracefully handle absence of optional `web` module

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e73d6de688327894dd98a69173c22