### PR TITLE
Add macOS-style web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,25 @@ This repository contains the early foundation for a cross-platform website bundl
 ```
 .
 ├── src/        # Application source code (Telegram bot and future backend)
+├── web/        # Static HTML and CSS
 ├── docs/       # Project documentation
 ├── README.md   # This file
 └── requirements.txt
 ```
+
+## Serving the Web Interface Locally
+
+You can preview the static pages using a small FastAPI application.
+
+1. **Install additional dependencies**
+   ```bash
+   pip install fastapi uvicorn
+   ```
+2. **Run the server**
+   ```bash
+   python -m src.serve_web
+   ```
+   Then open `http://127.0.0.1:8000` in your browser.
 
 ## License
 This project is licensed under the terms of the MIT license. See [LICENSE](LICENSE) for details.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 aiogram>=3.0.0
+fastapi>=0.110
+uvicorn>=0.27

--- a/src/serve_web.py
+++ b/src/serve_web.py
@@ -1,0 +1,10 @@
+"""Serve the static web directory using FastAPI."""
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+import uvicorn
+
+app = FastAPI()
+app.mount("/", StaticFiles(directory="web", html=True), name="static")
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Utilities</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="top-bar">
+        <span>🖥️ Utilities</span>
+    </header>
+    <main>
+        <h1>Welcome</h1>
+        <p>Access calculators and notes from this macOS-inspired interface.</p>
+    </main>
+    <nav class="dock">
+        <a href="#">Home</a>
+        <a href="#">Notes</a>
+        <a href="#">Calculator</a>
+    </nav>
+</body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,35 @@
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    background-color: #f5f5f5;
+}
+
+.top-bar {
+    background: linear-gradient(#f7f7f7, #e2e2e2);
+    padding: 8px;
+    color: #000;
+    text-align: center;
+    border-bottom: 1px solid #ccc;
+    font-weight: 500;
+}
+
+.dock {
+    position: fixed;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(255, 255, 255, 0.85);
+    border-radius: 16px;
+    padding: 8px 16px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.dock a {
+    margin: 0 8px;
+    text-decoration: none;
+    color: #007aff;
+}
+
+.dock a:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- add a minimal macOS-inspired HTML/CSS layout
- document local web serving with FastAPI
- provide a small FastAPI script for serving
- update dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e73becf848327a47eaccb98b9c7fa