### PR TITLE
Fix app import path

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,7 +3,7 @@
 from .bot import dp, main
 
 try:
-    from .web import app
+    from .serve_web import app
 except Exception:  # pragma: no cover - web is optional
     app = None
 


### PR DESCRIPTION
## Summary
- update FastAPI app import to use `serve_web`

## Testing
- `python -m py_compile src/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_685e7c9fd43883279208a65103cff0b3