### PR TITLE
Fix README server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,14 @@ This repository contains the early foundation for a cross-platform website bundl
 
 You can preview the static pages using a small FastAPI application.
 
-1. **Install additional dependencies**
-   ```bash
-   pip install fastapi uvicorn
-   ```
-2. **Run the server**
-   ```bash
-   python -m src.serve_web
-   ```
-   Then open `http://127.0.0.1:8000` in your browser.
+After installing the packages from `requirements.txt` (which already include
+`fastapi` and `uvicorn`), run:
+
+```bash
+python -m src.serve_web
+```
+
+Then open `http://127.0.0.1:8000` in your browser.
 
 ## License
 This project is licensed under the terms of the MIT license. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- point users to `requirements.txt` when serving web

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_685e7ca0eaf8832795dbaf5736507f70