### PR TITLE
Add import tests and compile workflow

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,16 @@
+name: Compile
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: python -m compileall -q src

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,67 @@
+import importlib
+import sys
+import types
+
+
+def mock_aiogram():
+    class Bot:
+        def __init__(self, token: str):
+            self.token = token
+
+    class Dispatcher:
+        def message(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            return decorator
+
+        async def start_polling(self, bot):
+            return None
+
+    aiogram = types.ModuleType("aiogram")
+    aiogram.Bot = Bot
+    aiogram.Dispatcher = Dispatcher
+
+    filters = types.ModuleType("aiogram.filters")
+    filters.CommandStart = object
+    aiogram.filters = filters
+    sys.modules["aiogram"] = aiogram
+    sys.modules["aiogram.filters"] = filters
+
+    types_mod = types.ModuleType("aiogram.types")
+    types_mod.Message = object
+    aiogram.types = types_mod
+    sys.modules["aiogram.types"] = types_mod
+
+
+def mock_fastapi_uvicorn():
+    class FastAPI:
+        def mount(self, *args, **kwargs):
+            pass
+
+    class StaticFiles:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fastapi = types.ModuleType("fastapi")
+    fastapi.FastAPI = FastAPI
+
+    staticfiles = types.ModuleType("fastapi.staticfiles")
+    staticfiles.StaticFiles = StaticFiles
+    fastapi.staticfiles = staticfiles
+    sys.modules["fastapi"] = fastapi
+    sys.modules["fastapi.staticfiles"] = staticfiles
+
+    uvicorn = types.ModuleType("uvicorn")
+    uvicorn.run = lambda *args, **kwargs: None
+    sys.modules["uvicorn"] = uvicorn
+
+
+def test_import_bot(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "x")
+    mock_aiogram()
+    assert importlib.import_module("src.bot")
+
+
+def test_import_serve_web():
+    mock_fastapi_uvicorn()
+    assert importlib.import_module("src.serve_web")


### PR DESCRIPTION
## Summary
- ensure `src.bot` and `src.serve_web` import in tests
- run bytecode compilation in GitHub Actions

## Testing
- `python -m compileall -q src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7ca2a0948327b045875ef1b3cc92