### PR TITLE
Improve bot startup and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This repository contains the early foundation for a cross-platform website bundl
 ## Requirements
 - Python 3.9+
 - A Telegram bot token obtained from [@BotFather](https://t.me/BotFather)
+- A `.env` file in the project root with `BOT_TOKEN` defined
 
 ## Setup
 1. **Clone the repository**
@@ -51,22 +52,13 @@ This repository contains the early foundation for a cross-platform website bundl
    pip install -r requirements.txt
    ```
 3. **Set the bot token**
-   Export your token as an environment variable:
+   Create a `.env` file in the project root containing your token:
 
-   **Unix/macOS**
-   ```bash
-   export BOT_TOKEN=<your-token-here>
+   ```env
+   BOT_TOKEN=<your-token-here>
    ```
 
-   **Windows (Command Prompt)**
-   ```cmd
-   set BOT_TOKEN=<your-token>
-   ```
-
-   **Windows (PowerShell)**
-   ```powershell
-   $env:BOT_TOKEN="<your-token>"
-   ```
+   Alternatively, you can export `BOT_TOKEN` as an environment variable.
 4. **Run the bot**
    ```bash
    python -m src.bot

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiogram>=3.0.0
 fastapi>=0.110
 uvicorn>=0.27
+python-dotenv>=1.0

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,10 +1,20 @@
 """Minimal Telegram bot using aiogram 3.x"""
 import asyncio
+import logging
 import os
 
 from aiogram import Bot, Dispatcher
+from aiogram.exceptions import TelegramAPIError
 from aiogram.filters import CommandStart
 from aiogram.types import Message
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - fallback for environments without python-dotenv
+    def load_dotenv() -> None:
+        return None
+
+logging.basicConfig(level=logging.INFO)
+load_dotenv()
 
 TOKEN = os.getenv("BOT_TOKEN")
 if not TOKEN:
@@ -21,7 +31,10 @@ async def start(message: Message) -> None:
 async def main() -> None:
     """Run the bot."""
     bot = Bot(TOKEN)
-    await dp.start_polling(bot)
+    try:
+        await dp.start_polling(bot)
+    except TelegramAPIError as e:
+        logging.exception("Telegram API error: %s", e)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -32,6 +32,11 @@ def mock_aiogram():
     aiogram.types = types_mod
     sys.modules["aiogram.types"] = types_mod
 
+    exceptions_mod = types.ModuleType("aiogram.exceptions")
+    exceptions_mod.TelegramAPIError = type("TelegramAPIError", (Exception,), {})
+    aiogram.exceptions = exceptions_mod
+    sys.modules["aiogram.exceptions"] = exceptions_mod
+
 
 def mock_fastapi_uvicorn():
     class FastAPI:


### PR DESCRIPTION
## Summary
- add fallback loading of `.env`
- set up logging and polling error handling
- document `.env` usage
- include `python-dotenv` dependency
- adjust tests for new imports

## Testing
- `pytest -q`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685e82dfca848327907e4dc48fe644c6