### PR TITLE
Add dotenv support for environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and replace the placeholder with your actual bot token
+BOT_TOKEN=

--- a/README.md
+++ b/README.md
@@ -51,21 +51,11 @@ This repository contains the early foundation for a cross-platform website bundl
    pip install -r requirements.txt
    ```
 3. **Set the bot token**
-   Export your token as an environment variable:
+   Copy `.env.example` to `.env` and edit the file to include your token:
 
-   **Unix/macOS**
    ```bash
-   export BOT_TOKEN=<your-token-here>
-   ```
-
-   **Windows (Command Prompt)**
-   ```cmd
-   set BOT_TOKEN=<your-token>
-   ```
-
-   **Windows (PowerShell)**
-   ```powershell
-   $env:BOT_TOKEN="<your-token>"
+   cp .env.example .env
+   # then open .env and set BOT_TOKEN=<your-token>
    ```
 4. **Run the bot**
    ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,21 +16,11 @@ This page collects basic setup details and the development roadmap for the websi
    pip install -r requirements.txt
    ```
 3. **Configure environment variables**
-   Set the Telegram bot token so the application can authenticate:
+   Copy `.env.example` to `.env` and edit the file to include your Telegram bot token:
 
-   **Unix/macOS**
    ```bash
-   export BOT_TOKEN=<your-token>
-   ```
-
-   **Windows (Command Prompt)**
-   ```cmd
-   set BOT_TOKEN=<your-token>
-   ```
-
-   **Windows (PowerShell)**
-   ```powershell
-   $env:BOT_TOKEN="<your-token>"
+   cp .env.example .env
+   # open .env and set BOT_TOKEN=<your-token>
    ```
 4. **Run the bot**
    ```bash
@@ -46,7 +36,7 @@ This page collects basic setup details and the development roadmap for the websi
 - **Web Backend**: APIs built with FastAPI.
 
 ## Environment Variables
-- `BOT_TOKEN` – Telegram token obtained from [@BotFather](https://t.me/BotFather). Required to run the bot.
+- `BOT_TOKEN` – Telegram token obtained from [@BotFather](https://t.me/BotFather). Required to run the bot. Define this in a `.env` file based on `.env.example`.
 
 ## Directory Structure
 ```text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiogram>=3.0.0
 fastapi>=0.110
 uvicorn>=0.27
+python-dotenv>=1.0

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,10 +1,17 @@
 """Minimal Telegram bot using aiogram 3.x"""
 import asyncio
 import os
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    def load_dotenv(*args, **kwargs):
+        return False
 
 from aiogram import Bot, Dispatcher
 from aiogram.filters import CommandStart
 from aiogram.types import Message
+
+load_dotenv()
 
 TOKEN = os.getenv("BOT_TOKEN")
 if not TOKEN:

--- a/src/serve_web.py
+++ b/src/serve_web.py
@@ -2,7 +2,13 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 import uvicorn
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    def load_dotenv(*args, **kwargs):
+        return False
 
+load_dotenv()
 app = FastAPI()
 app.mount("/", StaticFiles(directory="web", html=True), name="static")
 


### PR DESCRIPTION
## Summary
- add `python-dotenv` requirement
- load variables from `.env` in bot and web server modules
- provide `.env.example` template
- update README and docs for `.env` usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e82e117dc8327ae0cc6d904754988